### PR TITLE
Improve PDF output

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, render_template, request, send_file, abort
 from io import BytesIO
-from generator import svg_bytes_from_params
+from generator import svg_bytes_from_params, external_dims
 import cairosvg
 import webbrowser
 import threading
@@ -19,7 +19,17 @@ def index():
             R   = float(request.form["R"])
             ep1 = float(request.form["ep1"])    # = th1
 
-            svg_bytes = svg_bytes_from_params(L, B, H, R, ep1)
+            ext_dims = external_dims(L, B, H, ep1)
+            logo = app.static_folder + "/MB-print-logo11.png"
+            svg_bytes = svg_bytes_from_params(
+                L,
+                B,
+                H,
+                R,
+                ep1,
+                logo_path=logo,
+                ext_dims=ext_dims,
+            )
             pdf_bytes = cairosvg.svg2pdf(bytestring=svg_bytes)
 
             file_name = f"Box_{L:g}x{B:g}x{H:g}_{ep1:g}mm.pdf"

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
     </style>
 </head>
 <body>
-<img class="logo" src="https://www.mbprint.pl/wp-content/uploads/2020/07/MB-print-logo11.png" alt="MB print logo"/>
+<img class="logo" src="{{ url_for('static', filename='MB-print-logo11.png') }}" alt="MB print logo"/>
 <div class="lang-switch">
     <button type="button" data-lang="pl">PL</button>
     <button type="button" data-lang="en">EN</button>


### PR DESCRIPTION
## Summary
- center PDF drawing on the page
- add 20 mm margin, info label and logo inside generated PDF
- compute external box dimensions for info label
- use local MB print logo in the frontend

## Testing
- `python3 -m py_compile app.py generator.py`


------
https://chatgpt.com/codex/tasks/task_e_6873cc1ce55483268c7d2573cd5f12e5