### PR TITLE
Rotate layout before labeling

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -112,6 +112,27 @@ def svg_bytes_from_params(
     dwg_h = height + 2 * margin
 
     dwg = svgwrite.Drawing(size=(f"{dwg_w}mm", f"{dwg_h}mm"), profile="tiny")
+    # ensure transforms use mm units by matching viewBox to physical size
+    dwg.viewbox(width=dwg_w, height=dwg_h)
+
+    # group with translation to keep margin and center
+    content = dwg.g(transform=f"translate({margin - min_x},{margin - min_y})")
+    cut_layer = content.add(dwg.g(id="CUT", **CUT_STROKE))
+    fold_layer = content.add(dwg.g(id="FOLD", **FOLD_STROKE))
+
+    for kind, x0, y0, x1, y1 in segs:
+        layer = cut_layer if kind == "CUT" else fold_layer
+        layer.add(
+            dwg.line(
+                start=(f"{x0}mm", f"{y0}mm"),
+                end=(f"{x1}mm", f"{y1}mm"),
+            )
+        )
+
+    # Rotate entire sheet with lines 90 degrees counter-clockwise
+    rotated = dwg.g(transform=f"rotate(-90,{dwg_w/2},{dwg_h/2})")
+    rotated.add(content)
+    dwg.add(rotated)
 
     # Informational text on top margin split into three lines
     if ext_dims is not None:
@@ -130,22 +151,6 @@ def svg_bytes_from_params(
                     font_family="sans-serif",
                 )
             )
-
-    # group with translation to keep margin and center
-    content = dwg.g(transform=f"translate({margin - min_x},{margin - min_y})")
-    cut_layer = content.add(dwg.g(id="CUT", **CUT_STROKE))
-    fold_layer = content.add(dwg.g(id="FOLD", **FOLD_STROKE))
-
-    for kind, x0, y0, x1, y1 in segs:
-        layer = cut_layer if kind == "CUT" else fold_layer
-        layer.add(
-            dwg.line(
-                start=(f"{x0}mm", f"{y0}mm"),
-                end=(f"{x1}mm", f"{y1}mm"),
-            )
-        )
-
-    dwg.add(content)
 
     # Position logo in the upper right corner if provided
     if logo_path:


### PR DESCRIPTION
## Summary
- rotate generated red/blue line groups 90° CCW before adding labels
- fix translation/rotation units by adding a matching viewBox

## Testing
- `python -m py_compile app.py generator.py build_segments_from_cs.py segments_full.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687647dcc04c832693db665769f66358