### PR TITLE
Ensure pip is available in Nixpacks build

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,5 @@
 [phases.setup]
-nixPkgs = ["python311", "cairo", "pango", "gdk-pixbuf", "libffi", "pkg-config"]
+nixPkgs = ["python311", "python311Packages.pip", "cairo", "pango", "gdk-pixbuf", "libffi", "pkg-config"]
 
 [phases.install]
-cmds = ["python -m pip install --upgrade pip", "python -m pip install -r requirements.txt"]
+cmds = ["pip install --upgrade pip", "pip install -r requirements.txt"]


### PR DESCRIPTION
## Summary
- include python311Packages.pip in Nixpacks setup
- call pip executable directly during install phase

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68aae50693088326814b945b61755f7f